### PR TITLE
Speed up when using `fill_contiguous` instead of `draw_iter` [experimental, rough]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 
 use core::fmt::{self, Debug};
 use core::marker::PhantomData;
-use core::num::flt2dec::decoder;
 
 use embedded_graphics::prelude::{
     DrawTarget, ImageDrawable, OriginDimensions, Point, RgbColor, Size,


### PR DESCRIPTION
Hi,
First up this is nowhere near mergeable - it's more of a feature request with a really rough example.

Here's a video of a worst-case-scenario GIF I've got running on a Pi Pico (clocked to 266Mhz)

**Before:**

https://github.com/andelf/tinygif/assets/2095051/d0dc7239-50b7-4adc-aa2a-d2cdccd90c1a

**After:**

https://github.com/andelf/tinygif/assets/2095051/59cfcc39-f098-4370-b148-e6e16df1be87


My GIF knowledge isn't good enough to work out what's going on with the offset pixels (it's probably something silly I've missed), and the `DecodeIterWrapper` can definitely be refactored into something faster / nicer.

There's another issue wherein GIFs do this:

https://github.com/andelf/tinygif/assets/2095051/4d51a145-f074-4fef-8ca6-068c814f8f87

Rather than (with the current version):

https://github.com/andelf/tinygif/assets/2095051/1aadc1cd-8e81-47dc-b54b-fa3e6557c27f

Which is presumably some sort of optimisation where the GIF only redraws a portion of the gif & would, presumably, require some sort of internal framebuffer approach

Assuming this even can be done in a way which works, if you changed to have it as default you would lose the ability to show GIFs with transparency & the upcoming interlace support, so you might want to do a different export or hide it behind a feature or something to maintain that feature.


This is the worst case scenario GIF I've been testing with by the way, can see from this that even the **After** is running slow
![pattern](https://github.com/andelf/tinygif/assets/2095051/535d0081-476d-438b-a3e6-16aca9b0d439)

I'm probably not able to push this much further myself, but if you want to give it a go & need some additional help testing things then let me know.

Feel free to close this PR whenever.

Thanks